### PR TITLE
sunxi: Lower frequency

### DIFF
--- a/driver/product/kernel/drivers/gpu/arm/midgard/platform/sunxi/mali_kbase_config_platform.h
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/platform/sunxi/mali_kbase_config_platform.h
@@ -27,7 +27,7 @@
  * Attached value: number in kHz
  * Default value: NA
  */
-#define GPU_FREQ_KHZ_MAX (432000)
+#define GPU_FREQ_KHZ_MAX (312000)
 /**
  * Minimum frequency GPU will be clocked at. Given in kHz.
  * This must be specified as there is no default value.
@@ -35,7 +35,7 @@
  * Attached value: number in kHz
  * Default value: NA
  */
-#define GPU_FREQ_KHZ_MIN (432000)
+#define GPU_FREQ_KHZ_MIN (312000)
 
 /**
  * GPU_SPEED_FUNC - A pointer to a function that calculates the GPU clock

--- a/driver/product/kernel/drivers/gpu/arm/midgard/platform/sunxi/mali_kbase_config_sunxi.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/platform/sunxi/mali_kbase_config_sunxi.c
@@ -46,10 +46,10 @@ static int kbase_platform_init(struct kbase_device *kbdev)
 		reset_control_deassert(kbdev->mali_rst);
 	}
 
-	clk_set_rate(kbdev->clock, 432000000);
+	clk_set_rate(kbdev->clock, 312000000);
 
 	if (kbdev->regulator)
-		regulator_set_voltage(kbdev->regulator, 860000, INT_MAX);
+		regulator_set_voltage(kbdev->regulator, 810000, INT_MAX);
 
 	return 0;
 }


### PR DESCRIPTION
It seems that default frequency (432MHz) and corresponding voltage (860mV) doesn't work well without any kind of throttling. 

Lower this a bit.