### PR TITLE
fixes for Linux 5.6

### DIFF
--- a/driver/product/kernel/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_time.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_time.c
@@ -26,7 +26,7 @@
 #include <backend/gpu/mali_kbase_pm_internal.h>
 
 void kbase_backend_get_gpu_time(struct kbase_device *kbdev, u64 *cycle_counter,
-				u64 *system_time, struct timespec *ts)
+				u64 *system_time, struct timespec64 *ts)
 {
 	u32 hi1, hi2;
 
@@ -53,7 +53,7 @@ void kbase_backend_get_gpu_time(struct kbase_device *kbdev, u64 *cycle_counter,
 	} while (hi1 != hi2);
 
 	/* Record the CPU's idea of current time */
-	getrawmonotonic(ts);
+	ktime_get_raw_ts64(ts);
 
 	kbase_pm_release_gpu_cycle_counter(kbdev);
 }

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_defs.h
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_defs.h
@@ -997,7 +997,7 @@ enum kbase_trace_code {
  *                      in the trace message, used during dumping of the message.
  */
 struct kbase_trace {
-	struct timespec timestamp;
+	struct timespec64 timestamp;
 	u32 thread_id;
 	u32 cpu;
 	void *ctx;

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_device.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_device.c
@@ -346,7 +346,7 @@ void kbasep_trace_add(struct kbase_device *kbdev, enum kbase_trace_code code, vo
 	trace_msg->thread_id = task_pid_nr(current);
 	trace_msg->cpu = task_cpu(current);
 
-	getnstimeofday(&trace_msg->timestamp);
+	ktime_get_real_ts64(&trace_msg->timestamp);
 
 	trace_msg->code = code;
 	trace_msg->ctx = ctx;

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_hwaccess_time.h
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_hwaccess_time.h
@@ -33,11 +33,11 @@
  * @kbdev:		Device pointer
  * @cycle_counter:	Pointer to u64 to store cycle counter in
  * @system_time:	Pointer to u64 to store system time in
- * @ts:			Pointer to struct timespec to store current monotonic
+ * @ts:			Pointer to struct timespec64 to store current monotonic
  *			time in
  */
 void kbase_backend_get_gpu_time(struct kbase_device *kbdev, u64 *cycle_counter,
-				u64 *system_time, struct timespec *ts);
+				u64 *system_time, struct timespec64 *ts);
 
 /**
  * kbase_wait_write_flush() -  Wait for GPU write flush

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_hwcnt_backend_gpu.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_hwcnt_backend_gpu.c
@@ -73,10 +73,10 @@ struct kbase_hwcnt_backend_gpu {
 static u64 kbasep_hwcnt_backend_gpu_timestamp_ns(
 	struct kbase_hwcnt_backend *backend)
 {
-	struct timespec ts;
+	struct timespec64 ts;
 
 	(void)backend;
-	getrawmonotonic(&ts);
+	ktime_get_raw_ts64(&ts);
 	return (u64)ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
 }
 

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_softjobs.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_softjobs.c
@@ -135,7 +135,7 @@ static int kbase_dump_cpu_gpu_time(struct kbase_jd_atom *katom)
 {
 	struct kbase_vmap_struct map;
 	void *user_result;
-	struct timespec ts;
+	struct timespec64 ts;
 	struct base_dump_cpu_gpu_counters data;
 	u64 system_time;
 	u64 cycle_counter;

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_softjobs.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_softjobs.c
@@ -807,7 +807,7 @@ int kbase_mem_copy_from_extres(struct kbase_context *kctx,
 
 		for (i = 0; i < dma_to_copy/PAGE_SIZE; i++) {
 
-			void *extres_page = dma_buf_kmap(dma_buf, i);
+			void *extres_page = NULL; //dma_buf_kmap(dma_buf, i);
 
 			if (extres_page)
 				kbase_mem_copy_from_extres_page(kctx,
@@ -816,7 +816,7 @@ int kbase_mem_copy_from_extres(struct kbase_context *kctx,
 						&target_page_nr,
 						offset, &to_copy);
 
-			dma_buf_kunmap(dma_buf, i, extres_page);
+			//dma_buf_kunmap(dma_buf, i, extres_page);
 			if (target_page_nr >= buf_data->nr_pages)
 				break;
 		}

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_tlstream.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_tlstream.c
@@ -608,10 +608,10 @@ atomic_t kbase_tlstream_enabled = {0};
  */
 static u64 kbasep_tlstream_get_timestamp(void)
 {
-	struct timespec ts;
+	struct timespec64 ts;
 	u64             timestamp;
 
-	getrawmonotonic(&ts);
+	ktime_get_raw_ts64(&ts);
 	timestamp = (u64)ts.tv_sec * NSECS_IN_SEC + ts.tv_nsec;
 	return timestamp;
 }

--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_vinstr.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_vinstr.c
@@ -138,9 +138,9 @@ static const struct file_operations vinstr_client_fops = {
  */
 static u64 kbasep_vinstr_timestamp_ns(void)
 {
-	struct timespec ts;
+	struct timespec64 ts;
 
-	getrawmonotonic(&ts);
+	ktime_get_raw_ts64(&ts);
 	return (u64)ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
 }
 

--- a/driver/product/kernel/drivers/gpu/arm/midgard/tests/mali_kutf_irq_test/mali_kutf_irq_test_main.c
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/tests/mali_kutf_irq_test/mali_kutf_irq_test_main.c
@@ -92,9 +92,9 @@ static irqreturn_t kbase_gpu_irq_custom_handler(int irq, void *data)
 
 	val = kbase_reg_read(kbdev, GPU_CONTROL_REG(GPU_IRQ_STATUS));
 	if (val & TEST_IRQ) {
-		struct timespec tval;
+		struct timespec64 tval;
 
-		getnstimeofday(&tval);
+		ktime_get_real_ts64(&tval);
 		irq_time = SEC_TO_NANO(tval.tv_sec) + (tval.tv_nsec);
 
 		kbase_reg_write(kbdev, GPU_CONTROL_REG(GPU_IRQ_CLEAR), val);
@@ -183,12 +183,12 @@ static void mali_kutf_irq_latency(struct kutf_context *context)
 			GPU_IRQ_HANDLER);
 
 	for (i = 0; i < NR_TEST_IRQS; i++) {
-		struct timespec tval;
+		struct timespec64 tval;
 		u64 start_time;
 		int ret;
 
 		triggered = false;
-		getnstimeofday(&tval);
+		ktime_get_real_ts64(&tval);
 		start_time = SEC_TO_NANO(tval.tv_sec) + (tval.tv_nsec);
 
 		/* Trigger fake IRQ */


### PR DESCRIPTION
These are required when building on Linux 5.6 - same commits are used with mali-bifrost, see:

https://github.com/LibreELEC/mali-bifrost/commit/5a8ec1b9f7c45f17562e412fe2b992c45c09d0db
https://github.com/LibreELEC/mali-bifrost/commit/291486d76e939f460acc880bc34d1f6759ccfba0