### PR TITLE
mali_kbase_sync: update for close_fd in 5.11.0

### DIFF
--- a/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync.h
+++ b/driver/product/kernel/drivers/gpu/arm/midgard/mali_kbase_sync.h
@@ -32,6 +32,7 @@
 #define MALI_KBASE_SYNC_H
 
 #include <linux/syscalls.h>
+#include <linux/fdtable.h>
 #ifdef CONFIG_SYNC
 #include <sync.h>
 #endif
@@ -161,7 +162,9 @@ void kbase_sync_fence_out_remove(struct kbase_jd_atom *katom);
  */
 static inline void kbase_sync_fence_close_fd(int fd)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	close_fd(fd);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 	ksys_close(fd);
 #else
 	sys_close(fd);


### PR DESCRIPTION
Error with Kernel >= 5.11.0 and xu4 (samsung/exynos) 

Errors when building mali-midgard referring to implicit declaration of ksys_close()

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/li[…]yscalls.h?h=v5.15&id=1572bfdf21d4d50e51941498ffe0b56c2289f783

so close_fd() to be used instead of ksys_close()